### PR TITLE
Add Dockerfile that builds rune/datadraw

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+FROM ubuntu:23.04
+
+ENV DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
+    LC_ALL=C.UTF-8 LANG=C.UTF-8 LANGUAGE=C.UTF-8
+
+# Install dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    # "aclocal" is needed by "autogen.sh"
+    automake \
+    autotools-dev \
+    bison \
+    build-essential \
+    ca-certificates \
+    clang-14 \
+    flex \
+    git \
+    libgmp-dev \
+    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-14 100 \
+    && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-14 100
+
+WORKDIR /tmp
+
+# Build and install DataDraw
+RUN git clone https://github.com/waywardgeek/datadraw.git \
+    && cd datadraw \
+    && ./autogen.sh \
+    && ./configure \
+    && make \
+    && make install
+
+# Build and install Rune
+RUN git clone https://github.com/google/rune.git \
+    && git clone https://github.com/pornin/CTTK.git \
+    && cp CTTK/inc/cttk.h CTTK \
+    && cd rune \
+    && make \
+    # Some of these tests are expected to fail, that's OK
+    && ./runtests.sh \
+    # Will install under /usr/local/rune
+    && make install
+
+# Test that rune is working
+RUN echo "TESTING RUNE" \
+    && echo 'println "Hello, World!"' > hello.rn \
+    && rune -g hello.rn \
+    && ./hello \
+    && echo "Should have printed 'Hello, World!'"


### PR DESCRIPTION
(Note: I intend to add/update the docs for this feature, after the other PR I have for docs is either merged or rejected)

With this Dockerfile, it's possible to build the compiler by just running:

```sh
$ docker build -t rune-compiler:latest .
```

You can then compile rune files like this:
```sh
$ echo 'println "Hello, World!"' > hello.rn
$ docker run -v $(pwd):/tmp rune-compiler rune -g /tmp/hello.rn

$ ls | grep hello
hello
hello.ll
hello.rn

$ ./hello
Hello, World!
```

It's also possible to use this as a hermetic/reproducible environment to build the compiler/core libs, and then copy them into your host machine:

```sh
$ docker run -i -v $(pwd)/rune:/tmp rune-compiler:latest sh << COMMANDS
  cp -r /usr/local/bin /tmp
  cp -r /usr/local/lib/rune /tmp/lib
COMMANDS

$ tree rune -L 2
rune
├── bin
│   ├── datadraw
│   ├── dataview
│   └── rune
└── lib
    ├── builtin
    ├── io
    ├── libcttk.a
    ├── librune.a
    ├── math
    └── runtime

$ ./rune --help
Usage: rune [options] file
    -b        - Don't load bulitin Rune files.
    -g        - Include debug information for gdb.  Implies -l.
    -l <llvmfile> - Write LLVM IR to <llvmfile>.
    -n        - No clang.  Don't compile the resulting .ll output.
    -O        - Optimized build.  Passes -O3 to clang.
    -p <dir>  - Use <dir> as the root directory for packages.
    -t        - Execute unit tests for all modules.
    -U        - Unsafe mode.  Don't generate bounds checking, overflow
                detection, and destroyed object access detection.
    -x        - Invert the return code: 0 if we fail, and 1 if we pass.
    -X        - Use the new event driven binder.
```